### PR TITLE
add nodes to the index when they update as well

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -105,7 +105,9 @@ export default class App extends Component {
   }
 
   onExampleChanged(lang) {
-    this.setState(getInitialState(lang));
+    this.clearNodeSelection();
+    const { languages } = this.state;
+    this.setState({ ...getInitialState(lang), languages });
   }
 
   hasLanguage(lang) {

--- a/src/components/UASTViewer.js
+++ b/src/components/UASTViewer.js
@@ -14,13 +14,26 @@ const Container = styled.div`
   background: ${background.main};
   line-height: ${font.lineHeight.large};
   padding: 4px;
-`
+`;
 
 export default class UASTViewer extends Component {
   constructor(props) {
     super(props);
     this.index = new NodeIndex();
+    this.addToIndex = node => this.index.add(node);
+    this.resetIndex(props);
+  }
+
+  resetIndex({ ast }) {
+    this.index.clear();
     this.activeNode = null;
+    this.ast = ast;
+  }
+
+  componentWillUpdate(nextProps) {
+    if (this.ast !== nextProps.ast) {
+      this.resetIndex(nextProps);
+    }
   }
 
   selectNode({ line, ch }) {
@@ -41,7 +54,7 @@ export default class UASTViewer extends Component {
         <Node
           tree={this.props.ast}
           onNodeSelected={this.props.onNodeSelected}
-          onMount={this.index.add.bind(this.index)}
+          onMount={this.addToIndex}
         />
       </Container>
     );

--- a/src/components/uast/Node.js
+++ b/src/components/uast/Node.js
@@ -105,6 +105,21 @@ export default class Node extends Component {
     if (this.props.onMount) {
       this.props.onMount(this);
     }
+
+    this.tree = this.props.tree;
+  }
+
+  componentWillUpdate({ tree }) {
+    if (this.tree !== tree) {
+      this.setState({ highlighted: false });
+      this.tree = tree;
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.props.onMount) {
+      this.props.onMount(this);
+    }
   }
 
   onNodeSelected(e) {

--- a/src/components/uast/Node.test.js
+++ b/src/components/uast/Node.test.js
@@ -154,6 +154,14 @@ describe('Node', () => {
     expect(spy.mock.calls.length).toBe(1);
   });
 
+  it("calls onMount when it's updated", () => {
+    const spy = jest.fn();
+    const component = mount(<Node onMount={spy} tree={{}} />);
+    component.instance().forceUpdate(() => {
+      expect(spy.mock.calls.length).toBe(2);
+    });
+  });
+
   it('expands itself and all its ancestors', () => {
     const path = [{ expand: jest.fn() }, { expand: jest.fn() }];
     const wrapper = mount(

--- a/src/components/uast/NodeIndex.js
+++ b/src/components/uast/NodeIndex.js
@@ -3,6 +3,10 @@ export default class NodeIndex {
     this.index = [];
   }
 
+  clear() {
+    this.index = [];
+  }
+
   add(node) {
     if (!node.end || !node.end.Line || !node.end.Col) {
       return;
@@ -19,6 +23,11 @@ export default class NodeIndex {
 
     if (!idx[line][col]) {
       idx[line][col] = [node];
+      return;
+    }
+
+    // prevent duplicates on the index
+    if (idx[line][col].indexOf(node) >= 0) {
       return;
     }
 

--- a/src/components/uast/NodeIndex.test.js
+++ b/src/components/uast/NodeIndex.test.js
@@ -32,6 +32,17 @@ describe('NodeIndex', () => {
       expect(index.index[1][1].length).toBe(1);
     });
 
+    it('does not add a duplicated node', () => {
+      const node = {
+        start: { Line: 1, Col: 1 },
+        end: { Line: 1, Col: 1 }
+      };
+      const index = new NodeIndex();
+      index.add(node);
+      index.add(node);
+      expect(index.index[1][1].length).toBe(1);
+    });
+
     it('adds a node to the line if there are other nodes already', () => {
       const index = new NodeIndex();
       index.add(mkNode(mkPos(1, 1), mkPos(1, 1)));


### PR DESCRIPTION
Before this patch, nodes were not being added once they were
updated, for example, when the AST changed.
This PR introduces changes to keep the UASTViewer working even
when the AST changes.

The good solution would be getting rid of the NodeIndex as it is
right now and implement some more idiomatic way of handling that
as the current approach is very flaky and requires some hacks to
work properly, as can be seen in this PR.

But we'll leave the refactor for another time.