### PR TITLE
Fix recursive expand

### DIFF
--- a/src/components/uast/Node.js
+++ b/src/components/uast/Node.js
@@ -168,7 +168,9 @@ export default class Node extends Component {
 
   expand() {
     this.refs.collapsible.expand();
-    this.path.forEach(node => node.expand());
+    this.path.forEach(node => {
+      node.refs.collapsible.expand()
+    });
   }
 
   render() {
@@ -235,11 +237,6 @@ export function Property({ name, value }) {
 }
 
 export class Children extends Component {
-  expand() {
-    this.refs.collapsible.expand();
-    this.props.path.forEach(node => node.expand());
-  }
-
   render() {
     const {
       children,
@@ -252,13 +249,13 @@ export class Children extends Component {
 
     if (Array.isArray(children)) {
       return (
-        <CollapsibleItem name="children" ref="collapsible" label="[]Node">
+        <CollapsibleItem name="children" label="[]Node">
           {children.map((node, i) =>
             <Node
               key={i}
               tree={node}
               depth={depth}
-              path={path.concat([this])}
+              path={path}
               onNodeSelected={onNodeSelected}
               onMount={onMount}
               showLocations={showLocations}

--- a/src/components/uast/Node.test.js
+++ b/src/components/uast/Node.test.js
@@ -103,18 +103,6 @@ describe('Children', () => {
       <Children path={[]} children={children} depth={1} onMount={jest.fn()} />
     );
   });
-
-  it('expands itself and its ancestors when expand is called', () => {
-    const path = [{ expand: jest.fn() }, { expand: jest.fn() }];
-
-    const wrapper = mount(
-      <Children path={path} children={[]} depth={MAX_EXPANDED_DEPTH + 1} />
-    );
-
-    wrapper.instance().expand();
-    expect(wrapper.ref('collapsible').get(0).state.collapsed).toBe(false);
-    path.map(i => i.expand.mock.calls.length).forEach(i => expect(i).toBe(1));
-  });
 });
 
 test('Property renders correctly', () => {
@@ -163,14 +151,22 @@ describe('Node', () => {
   });
 
   it('expands itself and all its ancestors', () => {
-    const path = [{ expand: jest.fn() }, { expand: jest.fn() }];
+    const path = [
+      {refs: {collapsible: {expand: jest.fn()}}},
+      {refs: {collapsible: {expand: jest.fn()}}},
+    ];
+
+    const tree = {
+      expand: jest.fn(),
+    };
+
     const wrapper = mount(
-      <Node tree={{}} path={path} depth={MAX_EXPANDED_DEPTH + 1} />
+      <Node tree={tree} path={path} depth={MAX_EXPANDED_DEPTH + 1} />
     );
 
     wrapper.instance().expand();
     expect(wrapper.ref('collapsible').get(0).state.collapsed).toBe(false);
-    path.map(i => i.expand.mock.calls.length).forEach(i => expect(i).toBe(1));
+    path.map(node => node.refs.collapsible.expand.mock.calls.length).forEach(i => expect(i).toBe(1));
   });
 
   it('highlights itself when highlight is called', () => {


### PR DESCRIPTION
Since the `path` already contains all ancestor nodes, it is not needed to execute `expand` over each parent element (`Children` nor `CollapsibleItem`) but expand only the ancestors already defined in the node `path`

Fixes https://github.com/bblfsh/dashboard/issues/54