### PR TITLE
api: Upgrade to make it compatible with SDK v1.1

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -21,7 +21,7 @@ export function parse(language, code, serverUrl) {
     })
       .then(resp => resp.json())
       .then(({ status, errors, uast }) => {
-        if (status === 'ok') {
+        if (status === 0) {
           resolve(uast);
         } else {
           reject(errors ? errors.map(normalizeError) : ["unexpected error"]);

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -2,7 +2,7 @@ import { parse } from './api';
 
 describe('api/parse', () => {
   it('should return the UAST when the request is successful', () => {
-    fetch.mockResponse(JSON.stringify({ uast: 'ok', status: 'ok' }));
+    fetch.mockResponse(JSON.stringify({ uast: 'ok', status: 0 }));
 
     const promise = parse('python', 'def sum(a, b):\n  return a + b\n');
     expect(promise).resolves.toEqual('ok');


### PR DESCRIPTION
Signed-off-by: Alfredo Beaumont <alfredo.beaumont@gmail.com>

This update is required to make it compatible with SDK `v1.1`.
The server should be running at least `v1.1.1` to work with this change and new drivers.