### PR TITLE
Clean asset.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 Makefile.main
 .ci
 bin
+
+# Go assets
+server/asset/asset.go

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ SERVER_URL ?= /api
 BBLFSH_PORT ?= 9432
 API_PORT ?= 9999
 
+rebuild := $(shell cp server/asset/asset.go.tpl server/asset/asset.go)
+
 $(MAKEFILE):
 	@git clone --quiet $(CI_REPOSITORY) $(CI_FOLDER); \
 	cp $(CI_FOLDER)/$(MAKEFILE) .;

--- a/server/asset/asset.go.tpl
+++ b/server/asset/asset.go.tpl
@@ -1,0 +1,9 @@
+package asset
+
+func AssetDir(name string) ([]string, error) {
+	return nil, nil
+}
+
+func RestoreAssets(dir, name string) error {
+	return nil
+}


### PR DESCRIPTION
Workaround to avoid pushing `asset` package

Since `asset` package seems to be required to make the project buildable, this will create the required package when make runs
