### PR TITLE
Change base docker image to debian slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM alpine:3.6
+FROM debian:stretch-slim
 
-RUN apk add --no-cache device-mapper ca-certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+    ca-certificates \
+    libxml2 \
+    && apt-get clean
 ADD bin/bblfsh-dashboard /bin/bblfsh-dashboard
 ENTRYPOINT ["/bin/bblfsh-dashboard", "-addr", ":80"]


### PR DESCRIPTION
binary compiled with cgo don't work on alpine
 
we need cgo because of client-go and we need client-go because we need query filtering:
it was introduced here https://github.com/bblfsh/dashboard/pull/74