### PR TITLE
Improve error message when bblfsh cannot be reached

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -23,7 +23,7 @@ type Server struct {
 func New(addr string, version string) (*Server, error) {
 	client, err := bblfsh.NewClient(addr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Can't connect to bblfsh server: %s", err)
 	}
 
 	return &Server{


### PR DESCRIPTION
Fixes https://github.com/bblfsh/dashboard/issues/108

Now it looks like this:
```
$ go run server/cmd/bblfsh-dashboard/main.go -addr=":9876" -bblfsh-addr="127.0.0.1:1234"
FATA[0005] error starting new server at :9876: Can't connect to bblfsh server: context deadline exceeded
exit status 1
```

Is it clear enough? (imo, yes)