### PR TITLE
Put children of node to the end

### DIFF
--- a/src/components/uast/Node.js
+++ b/src/components/uast/Node.js
@@ -136,10 +136,6 @@ export class Node extends Component {
       >
         <Property name="internal_type" value={node.InternalType} />
         <Properties properties={node.Properties} />
-        <Children
-          ids={node.Children}
-          onNodeSelected={this.props.onNodeSelected}
-        />
         <Property name="token" value={node.Token} />
         {showLocations ? (
           <Position name="start_position" position={node.StartPosition} />
@@ -148,6 +144,10 @@ export class Node extends Component {
           <Position name="end_position" position={node.EndPosition} />
         ) : null}
         <Roles roles={node.Roles} />
+        <Children
+          ids={node.Children}
+          onNodeSelected={this.props.onNodeSelected}
+        />
       </CollapsibleItem>
     );
   }

--- a/src/components/uast/__snapshots__/Node.test.js.snap
+++ b/src/components/uast/__snapshots__/Node.test.js.snap
@@ -600,6 +600,77 @@ exports[`Node renders correctly 1`] = `
     </div>
     <div
       className="sc-bdVaJa jQbgOF"
+    >
+      <div
+        className="sc-bwzfXH hRiJmB"
+      >
+        <span
+          className="sc-bZQynM iOQEqP"
+        >
+          token
+        </span>
+        <span
+          className="sc-EHOje HnGWi"
+          type="string"
+        >
+          bar
+        </span>
+      </div>
+    </div>
+    <div
+      className="sc-bdVaJa jQbgOF"
+      onMouseMove={undefined}
+    >
+      <div
+        className="sc-htpNat ghHrsA"
+        onClick={[Function]}
+      >
+        <span
+          className="sc-bZQynM iOQEqP"
+        >
+          roles
+        </span>
+        <summary
+          className="sc-ifAKCX gaIEnP"
+        >
+          []Role
+        </summary>
+      </div>
+      <div
+        className="sc-bxivhb dJnrFt"
+      >
+        <div
+          className="sc-bdVaJa jQbgOF"
+        >
+          <div
+            className="sc-bwzfXH hRiJmB"
+          >
+            <span
+              className="sc-EHOje HnGWi"
+              type="string"
+            >
+              e
+            </span>
+          </div>
+        </div>
+        <div
+          className="sc-bdVaJa jQbgOF"
+        >
+          <div
+            className="sc-bwzfXH hRiJmB"
+          >
+            <span
+              className="sc-EHOje HnGWi"
+              type="string"
+            >
+              g
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="sc-bdVaJa jQbgOF"
       onMouseMove={undefined}
     >
       <div
@@ -798,77 +869,6 @@ exports[`Node renders correctly 1`] = `
                 </div>
               </div>
             </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="sc-bdVaJa jQbgOF"
-    >
-      <div
-        className="sc-bwzfXH hRiJmB"
-      >
-        <span
-          className="sc-bZQynM iOQEqP"
-        >
-          token
-        </span>
-        <span
-          className="sc-EHOje HnGWi"
-          type="string"
-        >
-          bar
-        </span>
-      </div>
-    </div>
-    <div
-      className="sc-bdVaJa jQbgOF"
-      onMouseMove={undefined}
-    >
-      <div
-        className="sc-htpNat ghHrsA"
-        onClick={[Function]}
-      >
-        <span
-          className="sc-bZQynM iOQEqP"
-        >
-          roles
-        </span>
-        <summary
-          className="sc-ifAKCX gaIEnP"
-        >
-          []Role
-        </summary>
-      </div>
-      <div
-        className="sc-bxivhb dJnrFt"
-      >
-        <div
-          className="sc-bdVaJa jQbgOF"
-        >
-          <div
-            className="sc-bwzfXH hRiJmB"
-          >
-            <span
-              className="sc-EHOje HnGWi"
-              type="string"
-            >
-              e
-            </span>
-          </div>
-        </div>
-        <div
-          className="sc-bdVaJa jQbgOF"
-        >
-          <div
-            className="sc-bwzfXH hRiJmB"
-          >
-            <span
-              className="sc-EHOje HnGWi"
-              type="string"
-            >
-              g
-            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes: https://github.com/bblfsh/dashboard/issues/101
Actually there is a hard-coded order for some "properties".
`InternalType, Properties, Token, Positions, Children`.
I changed that order and put `Children` to the end.

The properties inside `Properties` (yeah, confusing) are sorted already because it's dict and `Object.keys` returns keys in order. (even specification doesn't say so, but all browsers work like that)