### PR TITLE
Make more verbose the prettier error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ test-frontend: dependencies-frontend
 lint: dependencies-frontend
 	$(YARN) lint
 
+fix-lint-errors: dependencies-frontend
+	$(YARN) fix-lint-errors
+
 assets: | build dependencies-frontend
 	chmod -R go=r $(ASSETS_PATH); \
 	$(BINDATA) \
@@ -60,7 +63,7 @@ assets: | build dependencies-frontend
 build: dependencies-frontend
 	GENERATE_SOURCEMAP=false REACT_APP_SERVER_URL=$(SERVER_URL) $(YARN) build
 
-validate-commit: assets no-changes-in-commit
+validate-commit: assets fix-lint-errors no-changes-in-commit
 
 ## Compiles the dashboard assets, and serve the dashboard through its API
 serve:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "lint": "eslint 'src/**/*.js' && prettier -l 'src/**/*.js'"
+    "lint": "eslint 'src/**/*.js' && prettier -l 'src/**/*.js'",
+    "fix-lint-errors": "eslint --fix 'src/**/*.js'; prettier --write 'src/**/*.js'"
   }
 }


### PR DESCRIPTION
When `prettier` fails (ran by `make lint`) locally or in Travis, the error is not descriptive enough because it only returns the path of the file containing the error; if `eslint` fails, then `prettier` is not even ran.
```shell
$ eslint 'src/**/*.js' && prettier -l 'src/**/*.js'
src/state/examples.test.js
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [lint] Error 1
The command "make lint" exited with 2.
```

In this PR it is added a "fix" stage when validating commit, so if it was fixed something, then the `make validate-commit` will fail, showing the things that didn't follow the linters.
```shell
yarn fix-lint-errors
yarn run v1.5.1
$ eslint --fix 'src/**/*.js' || prettier --write 'src/**/*.js'
Done in 1.95s.
diff --git a/src/state/examples.test.js b/src/state/examples.test.js
index 747a7ed..37878b4 100644
--- a/src/state/examples.test.js
+++ b/src/state/examples.test.js
@@ -12,10 +12,7 @@ import {
   select,
 } from './examples';
 import { set as codeSet } from './code';
-import {
-  set as languageSet,
-  SELECT as LANG_SELECT,
-} from './languages';
+import { set as languageSet, SELECT as LANG_SELECT } from './languages';
 
 describe('examples/reducer', () => {
   it('SET', () => {
generated assets are out of sync
/projects/src/github.com/bblfsh/dashboard/.ci/Makefile.main:202: recipe for target 'no-changes-in-commit' failed
make: *** [no-changes-in-commit] Error 2
```